### PR TITLE
Don't verify write permissions on lower inodes on overlayfs

### DIFF
--- a/fs/overlayfs/inode.c
+++ b/fs/overlayfs/inode.c
@@ -128,6 +128,9 @@ int ovl_permission(struct inode *inode, int mask)
 			goto out_dput;
 	}
 
+	if (!is_upper)
+		mask |= MAY_OPEN_LOWER;
+
 	err = __inode_permission(realinode, mask);
 out_dput:
 	dput(alias);

--- a/include/linux/fs.h
+++ b/include/linux/fs.h
@@ -82,6 +82,7 @@ typedef void (dax_iodone_t)(struct buffer_head *bh_map, int uptodate);
 #define MAY_CHDIR		0x00000040
 /* called from RCU mode, don't block */
 #define MAY_NOT_BLOCK		0x00000080
+#define MAY_OPEN_LOWER		0x00000100
 
 /*
  * flags in file.f_mode.  Note that FMODE_READ and FMODE_WRITE must correspond

--- a/security/selinux/hooks.c
+++ b/security/selinux/hooks.c
@@ -2907,6 +2907,15 @@ static int selinux_inode_permission(struct inode *inode, int mask)
 	u32 audited, denied;
 
 	from_access = mask & MAY_ACCESS;
+
+	/*
+	 * If we're trying to open the lower layer of an overlay mount, don't
+	 * worry about write or append permissions - these will be verified
+	 * against the upper context
+	 */
+	if (mask & MAY_OPEN_LOWER)
+		mask &= ~(MAY_WRITE|MAY_APPEND);
+
 	mask &= (MAY_READ|MAY_WRITE|MAY_EXEC|MAY_APPEND);
 
 	/* No permission to check.  Existence test. */


### PR DESCRIPTION
If a user opens a file r/w on overlayfs, and if the underlying inode is
currently still on the lower fs, right now we're verifying whether selinux
policy permits writes to the selinux context on the underlying inode. This
is suboptimal, since we don't want confined processes to be able to write to
these files if they're able to escape from a container and so don't want to
permit this in policy. Have overlayfs pass down an additional flag when
verifying the permission on lower inodes, and mask off the write bits in
the selinux permissions check if that flag is set.