### PR TITLE
Fix unallocated memory access in TPM eventlog code

### DIFF
--- a/drivers/char/tpm/tpm_eventlog.c
+++ b/drivers/char/tpm/tpm_eventlog.c
@@ -244,7 +244,12 @@ static int tpm_binary_bios_measurements_show(struct seq_file *m, void *v)
 
 	tempPtr = (char *)&temp_event;
 
-	for (i = 0; i < sizeof(struct tcpa_event) + temp_event.event_size; i++)
+	for (i = 0; i < sizeof(struct tcpa_event); i++)
+		seq_putc(m, tempPtr[i]);
+
+	tempPtr = (char *)&event->event_data;
+
+	for (i = 0; i < temp_event.event_size; i++)
 		seq_putc(m, tempPtr[i]);
 
 	return 0;


### PR DESCRIPTION
Commit 0cc698 added support for handling endian fixups in the event log code
but broke the binary log file in the process. Keep the endian code, but read
the event data from the actual event rather than from unallocated RAM.