### PR TITLE
xfrm: Fix GSO for IPsec with GRE tunnel.

### DIFF
--- a/net/xfrm/xfrm_output.c
+++ b/net/xfrm/xfrm_output.c
@@ -102,6 +102,9 @@ static int xfrm_output_one(struct sk_buff *skb, int err)
 		if (xfrm_offload(skb)) {
 			x->type_offload->encap(x, skb);
 		} else {
+			/* Inner headers are invalid now. */
+			skb->encapsulation = 0;
+
 			err = x->type->output(x, skb);
 			if (err == -EINPROGRESS)
 				goto out;
@@ -205,7 +208,6 @@ int xfrm_output(struct sock *sk, struct sk_buff *skb)
 	int err;
 
 	secpath_reset(skb);
-	skb->encapsulation = 0;
 
 	if (xfrm_dev_offload_ok(skb, x)) {
 		struct sec_path *sp;


### PR DESCRIPTION
Backport 73b9fc49b4c0116a04eda3979f64ed9b540b153c to fix https://bugzilla.kernel.org/show_bug.cgi?id=197513 for coreos/bugs#2294 in stable.