### PR TITLE
Backport an iSCSI fix to 4.14.20

### DIFF
--- a/drivers/scsi/scsi_sysfs.c
+++ b/drivers/scsi/scsi_sysfs.c
@@ -1383,7 +1383,10 @@ static void __scsi_remove_target(struct scsi_target *starget)
 		 * check.
 		 */
 		if (sdev->channel != starget->channel ||
-		    sdev->id != starget->id ||
+		    sdev->id != starget->id)
+			continue;
+		if (sdev->sdev_state == SDEV_DEL ||
+		    sdev->sdev_state == SDEV_CANCEL ||
 		    !get_device(&sdev->sdev_gendev))
 			continue;
 		spin_unlock_irqrestore(shost->host_lock, flags);


### PR DESCRIPTION
This is for coreos/bugs#2357.  It hasn't yet received a response [upstream](https://www.spinics.net/lists/stable/msg216917.html), so we can carry it in case it isn't in a 4.14 kernel by the next releases.