### PR TITLE
Revert "xen-netfront: Fix race between device setup and open" for beta

### DIFF
--- a/drivers/net/xen-netfront.c
+++ b/drivers/net/xen-netfront.c
@@ -351,9 +351,6 @@ static int xennet_open(struct net_device *dev)
 	unsigned int i = 0;
 	struct netfront_queue *queue = NULL;
 
-	if (!np->queues)
-		return -ENODEV;
-
 	for (i = 0; i < num_queues; ++i) {
 		queue = &np->queues[i];
 		napi_enable(&queue->napi);
@@ -1361,8 +1358,18 @@ static int netfront_probe(struct xenbus_device *dev,
 #ifdef CONFIG_SYSFS
 	info->netdev->sysfs_groups[0] = &xennet_dev_group;
 #endif
+	err = register_netdev(info->netdev);
+	if (err) {
+		pr_warn("%s: register_netdev err=%d\n", __func__, err);
+		goto fail;
+	}
 
 	return 0;
+
+ fail:
+	xennet_free_netdev(netdev);
+	dev_set_drvdata(&dev->dev, NULL);
+	return err;
 }
 
 static void xennet_end_access(int ref, void *page)
@@ -1731,6 +1738,8 @@ static void xennet_destroy_queues(struct netfront_info *info)
 {
 	unsigned int i;
 
+	rtnl_lock();
+
 	for (i = 0; i < info->netdev->real_num_tx_queues; i++) {
 		struct netfront_queue *queue = &info->queues[i];
 
@@ -1738,6 +1747,8 @@ static void xennet_destroy_queues(struct netfront_info *info)
 			napi_disable(&queue->napi);
 		netif_napi_del(&queue->napi);
 	}
+
+	rtnl_unlock();
 
 	kfree(info->queues);
 	info->queues = NULL;
@@ -1754,6 +1765,8 @@ static int xennet_create_queues(struct netfront_info *info,
 	if (!info->queues)
 		return -ENOMEM;
 
+	rtnl_lock();
+
 	for (i = 0; i < *num_queues; i++) {
 		struct netfront_queue *queue = &info->queues[i];
 
@@ -1762,7 +1775,7 @@ static int xennet_create_queues(struct netfront_info *info,
 
 		ret = xennet_init_queue(queue);
 		if (ret < 0) {
-			dev_warn(&info->xbdev->dev,
+			dev_warn(&info->netdev->dev,
 				 "only created %d queues\n", i);
 			*num_queues = i;
 			break;
@@ -1776,8 +1789,10 @@ static int xennet_create_queues(struct netfront_info *info,
 
 	netif_set_real_num_tx_queues(info->netdev, *num_queues);
 
+	rtnl_unlock();
+
 	if (*num_queues == 0) {
-		dev_err(&info->xbdev->dev, "no queues\n");
+		dev_err(&info->netdev->dev, "no queues\n");
 		return -EINVAL;
 	}
 	return 0;
@@ -1814,7 +1829,6 @@ static int talk_to_netback(struct xenbus_device *dev,
 		goto out;
 	}
 
-	rtnl_lock();
 	if (info->queues)
 		xennet_destroy_queues(info);
 
@@ -1825,7 +1839,6 @@ static int talk_to_netback(struct xenbus_device *dev,
 		info->queues = NULL;
 		goto out;
 	}
-	rtnl_unlock();
 
 	/* Create shared ring, alloc event channel -- for each queue */
 	for (i = 0; i < num_queues; ++i) {
@@ -1922,10 +1935,8 @@ abort_transaction_no_dev_fatal:
 	xenbus_transaction_end(xbt, 1);
  destroy_ring:
 	xennet_disconnect_backend(info);
-	rtnl_lock();
 	xennet_destroy_queues(info);
  out:
-	rtnl_unlock();
 	device_unregister(&dev->dev);
 	return err;
 }
@@ -1954,15 +1965,6 @@ static int xennet_connect(struct net_device *dev)
 	rtnl_lock();
 	netdev_update_features(dev);
 	rtnl_unlock();
-
-	if (dev->reg_state == NETREG_UNINITIALIZED) {
-		err = register_netdev(dev);
-		if (err) {
-			pr_warn("%s: register_netdev err=%d\n", __func__, err);
-			device_unregister(&np->xbdev->dev);
-			return err;
-		}
-	}
 
 	/*
 	 * All public and private state should now be sane.  Get
@@ -2154,14 +2156,10 @@ static int xennet_remove(struct xenbus_device *dev)
 
 	xennet_disconnect_backend(info);
 
-	if (info->netdev->reg_state == NETREG_REGISTERED)
-		unregister_netdev(info->netdev);
+	unregister_netdev(info->netdev);
 
-	if (info->queues) {
-		rtnl_lock();
+	if (info->queues)
 		xennet_destroy_queues(info);
-		rtnl_unlock();
-	}
 	xennet_free_netdev(info->netdev);
 
 	return 0;


### PR DESCRIPTION
This reverts commit 70f3461c23ffb394676cb53c2eb1095208a52327.

This causes failures to set mtu > 1500 on some aws instances.