### PR TITLE
ovl: drop test for upperdir used as lowerdir for 4.19.56

### DIFF
--- a/fs/overlayfs/super.c
+++ b/fs/overlayfs/super.c
@@ -1289,12 +1289,6 @@ static int ovl_get_lower_layers(struct super_block *sb, struct ovl_fs *ofs,
 		if (err < 0)
 			goto out;
 
-		err = -EBUSY;
-		if (ovl_is_inuse(stack[i].dentry)) {
-			pr_err("overlayfs: lowerdir is in-use as upperdir/workdir\n");
-			goto out;
-		}
-
 		err = ovl_setup_trap(sb, stack[i].dentry, &trap, "lowerdir");
 		if (err)
 			goto out;


### PR DESCRIPTION
This is accidentally triggered by multiple versions of Docker.  Drop the test pending a Docker fix.

Reverts part of 0319ef1d40ff39d2c0f942a46fb73918669b2350.

https://github.com/moby/moby/issues/39475