### PR TITLE
Rebase 4.19.82 patches onto 4.19.84

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,8 @@ $(filter-out _all sub-make $(CURDIR)/Makefile, $(MAKECMDGOALS)) _all: sub-make
 
 # Invoke a second make in the output directory, passing relevant variables
 sub-make:
-	$(Q)$(MAKE) -C $(KBUILD_OUTPUT) KBUILD_SRC=$(CURDIR) \
+	$(Q)$(MAKE) -C $(KBUILD_OUTPUT) \
+	KBUILD_SRC=$(shell realpath --relative-to=$(KBUILD_OUTPUT) $(CURDIR)) \
 	-f $(CURDIR)/Makefile $(filter-out _all sub-make,$(MAKECMDGOALS))
 
 # Leave processing to above invocation of make

--- a/net/netfilter/Kconfig
+++ b/net/netfilter/Kconfig
@@ -70,6 +70,14 @@ config NF_CONNTRACK
 
 	  To compile it as a module, choose M here.  If unsure, say N.
 
+config NF_CONNTRACK_IPV4_COMPAT
+	tristate "Netfilter connection tracking IPv4 compatibility module"
+	depends on NF_CONNTRACK
+	default NF_CONNTRACK
+	help
+	  Compatibility nf_conntrack_ipv4 module that loads nf_conntrack.ko,
+	  since kube-proxy cares about the names of loaded kernel modules.
+
 config NF_LOG_COMMON
 	tristate
 

--- a/net/netfilter/Makefile
+++ b/net/netfilter/Makefile
@@ -24,6 +24,7 @@ obj-$(CONFIG_NETFILTER_NETLINK_OSF) += nfnetlink_osf.o
 
 # connection tracking
 obj-$(CONFIG_NF_CONNTRACK) += nf_conntrack.o
+obj-$(CONFIG_NF_CONNTRACK_IPV4_COMPAT) += nf_conntrack_ipv4.o
 
 obj-$(CONFIG_NF_CT_PROTO_GRE) += nf_conntrack_proto_gre.o
 

--- a/net/netfilter/nf_conntrack_ipv4.c
+++ b/net/netfilter/nf_conntrack_ipv4.c
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Compatibility nf_conntrack_ipv4 module that depends on nf_conntrack
+ * to keep kube-proxy happy.
+ *
+ * Copyright (c) 2018 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ */
+
+#include <linux/module.h>
+#include <linux/printk.h>
+#include <net/netfilter/nf_conntrack.h>
+
+unsigned int *pointer_to_nf_conntrack_data = &nf_conntrack_max;
+
+static int __init nf_conntrack_ipv4_init(void) {
+	pr_notice("nf_conntrack_ipv4: loaded compatibility alias for nf_conntrack\n");
+	return 0;
+}
+
+static void __exit nf_conntrack_ipv4_exit(void) {}
+
+module_init(nf_conntrack_ipv4_init);
+module_exit(nf_conntrack_ipv4_exit);
+
+MODULE_DESCRIPTION("kube-proxy compatibility wrapper for nf_conntrack.ko");
+MODULE_LICENSE("GPL");

--- a/tools/lib/subcmd/Makefile
+++ b/tools/lib/subcmd/Makefile
@@ -39,6 +39,9 @@ ifneq ($(WERROR),0)
   CFLAGS += -Werror
 endif
 
+# Don't fail on fallthrough with newer GCCs.
+CFLAGS += -Wno-error=implicit-fallthrough
+
 CFLAGS += -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE
 
 CFLAGS += -I$(srctree)/tools/include/


### PR DESCRIPTION
The scheduler patches went upstream in coreos/linux@502bd151448c2c76a927b26783e5538875c534ff and coreos/linux@e9c0fc4a7ccd9fc28e78685d17c1943839c5579a.